### PR TITLE
[python] massive speedup with 1 line change: np.power has huge overhead  

### DIFF
--- a/python/multitaper_spectrogram_python.py
+++ b/python/multitaper_spectrogram_python.py
@@ -465,7 +465,7 @@ def calc_mts_segment(data_segment, dpss_tapers, nfft, freq_inds, detrend_opt, nu
     fft_data = np.fft.fft(tapered_data, nfft, axis=0)
 
     # Compute the weighted mean spectral power across tapers (STEP 4)
-    spower = np.power(np.imag(fft_data), 2) + np.power(np.real(fft_data), 2)
+    spower = np.imag(fft_data)**2 + np.real(fft_data)**2
     if weighting == 'adapt':
         # adaptive weights - for colored noise spectrum (Percival & Walden p368-370)
         tpower = np.dot(np.transpose(data_segment), (data_segment/len(data_segment)))


### PR DESCRIPTION
I profiled the python and noticed that there is a massive overhead when using
`np.power` for a power of 2, compared to the elementwise `**2` (or `np.square`).
The power implementation is more generic, and not needed here, and as this is within the hot path of `calc_mts_segment` it's absurdely expensive.

It turns out that **77%** of the compute time within the `calc_mts_segment` function is spent on that one line that just computes the mean spectral power across tapers.

Changing that speeds up the example (single core, couldn't benchmark it otherwise) on my machine from `Total time: 0.381273 s ` to `Total time: 0.102679 s`.

Below is the profiler output for the example using a single core, for before and after.

```
Multitaper Spectrogram Properties:
     Spectral Resolution: 1.5Hz
     Window Length: 4.0s
     Window Step: 1.0s
     Time Half-Bandwidth Product: 3
     Number of Tapers: 5
     Frequency Range: 0-25Hz
     NFFT: 1024
     Detrend: constant


 Multitaper compute time: 0.42 seconds
Wrote profile results to 'example.py.lprof'
Timer unit: 1e-06 s

Total time: 0.381273 s
File: /home/fabricio/projects/tmp/multitaper_toolbox/python/multitaper_spectrogram_python.py
Function: calc_mts_segment at line 429

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   429                                           @profile
   430                                           def calc_mts_segment(data_segment, dpss_tapers, nfft, freq_inds, detrend_opt, num_tapers, dpss_eigen, weighting, wt):
   431                                               """ Helper function to calculate the multitaper spectrum of a single segment of data
   432                                                   Arguments:
   433                                                       data_segment (1d np.array): One window worth of time-series data -- required
   434                                                       dpss_tapers (2d np.array): Parameters for the DPSS tapers to be used.
   435                                                                                  Dimensions are (num_tapers, winsize_samples) -- required
   436                                                       nfft (int): length of signal to calculate fft on -- required
   437                                                       freq_inds (1d np array): boolean array of which frequencies are being analyzed in
   438                                                                                 an array of frequencies from 0 to fs with steps of fs/nfft
   439                                                       detrend_opt (str): detrend data window ('linear' (default), 'constant', 'off')
   440                                                       num_tapers (int): number of tapers being used
   441                                                       dpss_eigen (np array):
   442                                                       weighting (str):
   443                                                       wt (int or np array):
   444                                                   Returns:
   445                                                       mt_spectrum (1d np.array): spectral power for single window
   446                                               """
   447
   448                                               # If segment has all zeros, return vector of zeros
   449       596       2633.2      4.4      0.7      if all(data_segment == 0):
   450                                                   ret = np.empty(sum(freq_inds))
   451                                                   ret.fill(0)
   452                                                   return ret
   453
   454       596       6627.2     11.1      1.7      if any(np.isnan(data_segment)):
   455                                                   ret = np.empty(sum(freq_inds))
   456                                                   ret.fill(np.nan)
   457                                                   return ret
   458
   459                                               # Option to detrend data to remove low frequency DC component
   460       596        221.5      0.4      0.1      if detrend_opt != 'off':
   461       596      24015.3     40.3      6.3          data_segment = detrend(data_segment, type=detrend_opt)
   462
   463                                               # Multiply data by dpss tapers (STEP 2)
   464       596      17048.8     28.6      4.5      tapered_data = np.multiply(np.mat(data_segment).T, np.mat(dpss_tapers.T))
   465
   466                                               # Compute the FFT (STEP 3)
   467       596      29597.3     49.7      7.8      fft_data = np.fft.fft(tapered_data, nfft, axis=0)
   468
   469                                               # Compute the weighted mean spectral power across tapers (STEP 4)
   470       596     294117.5    493.5     77.1      spower = np.power(np.imag(fft_data), 2) + np.power(np.real(fft_data), 2)
   471       596        283.6      0.5      0.1      if weighting == 'adapt':
   472                                                   # adaptive weights - for colored noise spectrum (Percival & Walden p368-370)
   473                                                   tpower = np.dot(np.transpose(data_segment), (data_segment/len(data_segment)))
   474                                                   spower_iter = np.mean(spower[:, 0:2], 1)
   475                                                   spower_iter = spower_iter[:, np.newaxis]
   476                                                   a = (1 - dpss_eigen) * tpower
   477                                                   for i in range(3):  # 3 iterations only
   478                                                       # Calc the MSE weights
   479                                                       b = np.dot(spower_iter, np.ones((1, num_tapers))) / ((np.dot(spower_iter, np.transpose(dpss_eigen))) +
   480                                                                                                            (np.ones((nfft, 1)) * np.transpose(a)))
   481                                                       # Calc new spectral estimate
   482                                                       wk = (b**2) * np.dot(np.ones((nfft, 1)), np.transpose(dpss_eigen))
   483                                                       spower_iter = np.sum((np.transpose(wk) * np.transpose(spower)), 0) / np.sum(wk, 1)
   484                                                       spower_iter = spower_iter[:, np.newaxis]
   485
   486                                                   mt_spectrum = np.squeeze(spower_iter)
   487
   488                                               else:
   489                                                   # eigenvalue or uniform weights
   490       596       3017.5      5.1      0.8          mt_spectrum = np.dot(spower, wt)
   491       596       2548.3      4.3      0.7          mt_spectrum = np.reshape(mt_spectrum, nfft)  # reshape to 1D
   492
   493       596       1162.7      2.0      0.3      return mt_spectrum[freq_inds]

```

```



Multitaper Spectrogram Properties:
     Spectral Resolution: 1.5Hz
     Window Length: 4.0s
     Window Step: 1.0s
     Time Half-Bandwidth Product: 3
     Number of Tapers: 5
     Frequency Range: 0-25Hz
     NFFT: 1024
     Detrend: constant


 Multitaper compute time: 0.14 seconds
Wrote profile results to 'example.py.lprof'
Timer unit: 1e-06 s

Total time: 0.102679 s
File: /home/fabricio/projects/tmp/multitaper_toolbox/python/multitaper_spectrogram_python.py
Function: calc_mts_segment at line 429

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   429                                           @profile
   430                                           def calc_mts_segment(data_segment, dpss_tapers, nfft, freq_inds, detrend_opt, num_tapers, dpss_eigen, weighting, wt):
   431                                               """ Helper function to calculate the multitaper spectrum of a single segment of data
   432                                                   Arguments:
   433                                                       data_segment (1d np.array): One window worth of time-series data -- required
   434                                                       dpss_tapers (2d np.array): Parameters for the DPSS tapers to be used.
   435                                                                                  Dimensions are (num_tapers, winsize_samples) -- required
   436                                                       nfft (int): length of signal to calculate fft on -- required
   437                                                       freq_inds (1d np array): boolean array of which frequencies are being analyzed in
   438                                                                                 an array of frequencies from 0 to fs with steps of fs/nfft
   439                                                       detrend_opt (str): detrend data window ('linear' (default), 'constant', 'off')
   440                                                       num_tapers (int): number of tapers being used
   441                                                       dpss_eigen (np array):
   442                                                       weighting (str):
   443                                                       wt (int or np array):
   444                                                   Returns:
   445                                                       mt_spectrum (1d np.array): spectral power for single window
   446                                               """
   447
   448                                               # If segment has all zeros, return vector of zeros
   449       596       3061.1      5.1      3.0      if all(data_segment == 0):
   450                                                   ret = np.empty(sum(freq_inds))
   451                                                   ret.fill(0)
   452                                                   return ret
   453
   454       596       6960.6     11.7      6.8      if any(np.isnan(data_segment)):
   455                                                   ret = np.empty(sum(freq_inds))
   456                                                   ret.fill(np.nan)
   457                                                   return ret
   458
   459                                               # Option to detrend data to remove low frequency DC component
   460       596        278.2      0.5      0.3      if detrend_opt != 'off':
   461       596      26162.2     43.9     25.5          data_segment = detrend(data_segment, type=detrend_opt)
   462
   463                                               # Multiply data by dpss tapers (STEP 2)
   464       596      18832.9     31.6     18.3      tapered_data = np.multiply(np.mat(data_segment).T, np.mat(dpss_tapers.T))
   465
   466                                               # Compute the FFT (STEP 3)
   467       596      32048.3     53.8     31.2      fft_data = np.fft.fft(tapered_data, nfft, axis=0)
   468
   469                                               # Compute the weighted mean spectral power across tapers (STEP 4)
   470       596       8181.4     13.7      8.0      spower = np.imag(fft_data)**2 + np.real(fft_data)**2
   471       596        270.9      0.5      0.3      if weighting == 'adapt':
   472                                                   # adaptive weights - for colored noise spectrum (Percival & Walden p368-370)
   473                                                   tpower = np.dot(np.transpose(data_segment), (data_segment/len(data_segment)))
   474                                                   spower_iter = np.mean(spower[:, 0:2], 1)
   475                                                   spower_iter = spower_iter[:, np.newaxis]
   476                                                   a = (1 - dpss_eigen) * tpower
   477                                                   for i in range(3):  # 3 iterations only
   478                                                       # Calc the MSE weights
   479                                                       b = np.dot(spower_iter, np.ones((1, num_tapers))) / ((np.dot(spower_iter, np.transpose(dpss_eigen))) +
   480                                                                                                            (np.ones((nfft, 1)) * np.transpose(a)))
   481                                                       # Calc new spectral estimate
   482                                                       wk = (b**2) * np.dot(np.ones((nfft, 1)), np.transpose(dpss_eigen))
   483                                                       spower_iter = np.sum((np.transpose(wk) * np.transpose(spower)), 0) / np.sum(wk, 1)
   484                                                       spower_iter = spower_iter[:, np.newaxis]
   485
   486                                                   mt_spectrum = np.squeeze(spower_iter)
   487
   488                                               else:
   489                                                   # eigenvalue or uniform weights
   490       596       3090.4      5.2      3.0          mt_spectrum = np.dot(spower, wt)
   491       596       2551.3      4.3      2.5          mt_spectrum = np.reshape(mt_spectrum, nfft)  # reshape to 1D
   492
   493       596       1241.9      2.1      1.2      return mt_spectrum[freq_inds]
```